### PR TITLE
Fix grammar of negation operator

### DIFF
--- a/grammar.ne
+++ b/grammar.ne
@@ -51,7 +51,7 @@ unaryExpression ->
         | number {% ([value]) => new NumberConstant(value) %}
         | string {% ([value]) => new StringConstant(value) %}
         | variablePath {% ([path]) => new Variable(path)  %}
-        | "!" _ expression {% ([,,node]) => new NegationExpression(node) %}
+        | "!" _ unaryExpression {% ([,,node]) => new NegationExpression(node) %}
         | "(" _ expression _ ")" {% d => d[2] %}
 
 variablePath ->

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -186,7 +186,7 @@ var grammar = {
     {"name": "unaryExpression", "symbols": ["number"], "postprocess": ([value]) => new NumberConstant(value)},
     {"name": "unaryExpression", "symbols": ["string"], "postprocess": ([value]) => new StringConstant(value)},
     {"name": "unaryExpression", "symbols": ["variablePath"], "postprocess": ([path]) => new Variable(path)},
-    {"name": "unaryExpression", "symbols": [{"literal":"!"}, "_", "expression"], "postprocess": ([,,node]) => new NegationExpression(node)},
+    {"name": "unaryExpression", "symbols": [{"literal":"!"}, "_", "unaryExpression"], "postprocess": ([,,node]) => new NegationExpression(node)},
     {"name": "unaryExpression", "symbols": [{"literal":"("}, "_", "expression", "_", {"literal":")"}], "postprocess": d => d[2]},
     {"name": "variablePath", "symbols": ["variable"], "postprocess": id},
     {"name": "variablePath", "symbols": ["variablePath", "_", {"literal":"."}, "_", "variableAfterDot"], "postprocess": d => [...arrayify(d[0]), d[4]]},

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -153,6 +153,10 @@ describe("evaluate()", function () {
     evaluateAssert("!true", {}, false);
     evaluateAssert("!false", {}, true);
     evaluateAssert("!var", { var: false }, true);
+    evaluateAssert("!a && b && c", { a: false, b: false, c: true }, false);
+    evaluateAssert("!(a && b) && c", { a: false, b: false, c: true }, true);
+    evaluateAssert("a && !b && c", { a: true, b: false, c: true }, true);
+    evaluateAssert("!a || b && c", { a: false, b: false, c: true }, true);
   });
 
   it("should work with a single literal", function () {


### PR DESCRIPTION
The grammar for negation was using an expression, however [ECMAScript defines the negation operator as being on a unary expression](https://262.ecma-international.org/#sec-logical-not-operator). The current grammar resulted in expressions like `!A && B` being parsed as `!(A && B)` rather than `(!A) && B`.